### PR TITLE
Some placeholder (but perhaps not stub?) text for the about page.

### DIFF
--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -1,5 +1,33 @@
 <template>
-  <div class="about">
-    <h1>This is an about page</h1>
-  </div>
+  <v-container fluid>
+    <v-slide-y-transition mode="out-in">
+      <v-layout column align-center>
+        <v-flex xs12 lg8>
+          <v-card width="100%">
+            <v-card-title
+              primary-title
+              class="display-1 primary white--text">
+              About
+            </v-card-title>
+            <v-card-text>
+              <v-flex>
+                <div class="subheading">
+                  <p>
+                    Registering to vote in the United States can be confusing! 
+                    <a href="/">registertovote.how</a> hopes to take away some of the frustrations,
+                    by providing visitors a link to their states online voting registration (when available).
+                  </p>
+
+                  <p>
+                    The web site is open source and contributions, fixes, ideas, etc are welcome!  
+                    Stop by at <a href="https://github.com/lyonsbp/registertovote.how" target="_blank">https://github.com/lyonsbp/registertovote.how</a>
+                  </p>
+                </div>
+              </v-flex>
+            </v-card-text>
+          </v-card>
+        </v-flex>
+      </v-layout>
+    </v-slide-y-transition>
+  </v-container>
 </template>


### PR DESCRIPTION
#4 added the two pages (Home and About) to the navigation menu, the about page is currently a stub page from that branch.  Here's a start to some information that could be present in the about page.

Don't know vue, or much UI ( :D ), so follow the same general layout of the main page.